### PR TITLE
Support for .list layout and UICollectionLayoutListConfiguration

### DIFF
--- a/RibbonKit.xcodeproj/project.pbxproj
+++ b/RibbonKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0AC30F76278F20BE00ED8059 /* RibbonListCollectionViewListConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC30F75278F20BD00ED8059 /* RibbonListCollectionViewListConfiguration.swift */; };
 		303F475924CF6E7900763149 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 303F475824CF6E7900763149 /* Assets.xcassets */; };
 		303F475C24CF6E7900763149 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 303F475A24CF6E7900763149 /* LaunchScreen.storyboard */; };
 		303F476224CF6EFC00763149 /* ColorGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3044596A24C7B4D90062BA54 /* ColorGroup.swift */; };
@@ -60,6 +61,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0AC30F75278F20BD00ED8059 /* RibbonListCollectionViewListConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RibbonListCollectionViewListConfiguration.swift; sourceTree = "<group>"; };
 		303F474F24CF6E7800763149 /* Example-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		303F475824CF6E7900763149 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		303F475B24CF6E7900763149 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -188,6 +190,7 @@
 		30F07A2C24C867A100BFFE5E /* List */ = {
 			isa = PBXGroup;
 			children = (
+				0AC30F75278F20BD00ED8059 /* RibbonListCollectionViewListConfiguration.swift */,
 				30DFDD4B2721B42500EAAF87 /* RibbonListView.swift */,
 				30B56F192730A54D006AB071 /* RibbonListViewScrollingBehaviour.swift */,
 				30B56F172730A4A8006AB071 /* RibbonListViewDiffableDataSource.swift */,
@@ -422,6 +425,7 @@
 				3044596324C7B15D0062BA54 /* RibbonListSectionConfiguration.swift in Sources */,
 				30B56F1A2730A54D006AB071 /* RibbonListViewScrollingBehaviour.swift in Sources */,
 				30F07A3024C867CF00BFFE5E /* RibbonListViewDelegate.swift in Sources */,
+				0AC30F76278F20BE00ED8059 /* RibbonListCollectionViewListConfiguration.swift in Sources */,
 				30DFDD4C2721B42500EAAF87 /* RibbonListView.swift in Sources */,
 				3048262925B876FD001AFC2C /* RibbonListViewFocusUpdateContext.swift in Sources */,
 				30B56F182730A4A8006AB071 /* RibbonListViewDiffableDataSource.swift in Sources */,

--- a/RibbonKit.xcodeproj/project.pbxproj
+++ b/RibbonKit.xcodeproj/project.pbxproj
@@ -722,7 +722,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = RibbonKit.xcodeproj/RibbonKit_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -734,7 +734,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = RibbonKit;
-				TVOS_DEPLOYMENT_TARGET = 13.0;
+				TVOS_DEPLOYMENT_TARGET = 14.0;
 			};
 			name = Debug;
 		};
@@ -748,7 +748,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = RibbonKit.xcodeproj/RibbonKit_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -760,7 +760,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = RibbonKit;
-				TVOS_DEPLOYMENT_TARGET = 13.0;
+				TVOS_DEPLOYMENT_TARGET = 14.0;
 			};
 			name = Release;
 		};

--- a/Shared/Data/ColorGroup.swift
+++ b/Shared/Data/ColorGroup.swift
@@ -139,7 +139,7 @@ extension ColorGroup {
             footerTitle: "A range of yellow colors to please your eyes. You can click on a cell to change its color.",
             configuration:
                 RibbonListSectionConfiguration(
-                    layout: .list()
+                    layout: .list(.init(appearance: .plain))
                 ),
             hue: .yellow,
             luminosity: .light

--- a/Shared/Data/ColorGroup.swift
+++ b/Shared/Data/ColorGroup.swift
@@ -133,6 +133,16 @@ extension ColorGroup {
                 ),
             hue: .green,
             luminosity: .light
+        ),
+        ColorGroup(
+            headerTitle: "Yellow-ish Colors",
+            footerTitle: "A range of yellow colors to please your eyes. You can click on a cell to change its color.",
+            configuration:
+                RibbonListSectionConfiguration(
+                    layout: .list()
+                ),
+            hue: .yellow,
+            luminosity: .light
         )
     ]
 }

--- a/Shared/Data/ColorGroup.swift
+++ b/Shared/Data/ColorGroup.swift
@@ -25,7 +25,7 @@ class ColorGroup {
     init(headerTitle: String, footerTitle: String, configuration: RibbonListSectionConfiguration, hue: Hue, luminosity: Luminosity) {
         self.headerTitle = headerTitle
         self.footerTitle = footerTitle
-        self.colors = (0..<10).map { _ in .init(color: randomColor(hue: hue, luminosity: luminosity)) }
+        self.colors = (0..<3).map { _ in .init(color: randomColor(hue: hue, luminosity: luminosity)) }
         self.configuration = configuration
         self.hue = hue
         self.luminosity = luminosity

--- a/Sources/RibbonKit/List/RibbonListCollectionViewListConfiguration.swift
+++ b/Sources/RibbonKit/List/RibbonListCollectionViewListConfiguration.swift
@@ -1,0 +1,27 @@
+//  Copyright © 2022 Roman Blum. All rights reserved.
+
+import UIKit
+
+public struct RibbonListCollectionViewListConfiguration: Hashable {
+
+    public var appearance: UICollectionLayoutListConfiguration.Appearance
+    public var backgroundColor: UIColor?
+    public var showsSeparators: Bool = true
+
+    public init(
+        appearance: UICollectionLayoutListConfiguration.Appearance,
+        backgroundColor: UIColor? = nil,
+        showsSeparators: Bool = true
+    ) {
+        self.appearance = appearance
+        self.backgroundColor = backgroundColor
+        self.showsSeparators = showsSeparators
+    }
+    
+    func asCollectionLayoutListConfiguration() -> UICollectionLayoutListConfiguration {
+        var config = UICollectionLayoutListConfiguration(appearance: appearance)
+        config.backgroundColor = backgroundColor
+        config.showsSeparators = showsSeparators
+        return config
+    }
+}

--- a/Sources/RibbonKit/List/RibbonListCollectionViewListConfiguration.swift
+++ b/Sources/RibbonKit/List/RibbonListCollectionViewListConfiguration.swift
@@ -6,22 +6,25 @@ public struct RibbonListCollectionViewListConfiguration: Hashable {
 
     public var appearance: UICollectionLayoutListConfiguration.Appearance
     public var backgroundColor: UIColor?
+
+    #if os(iOS)
     public var showsSeparators: Bool = true
+    #endif
 
     public init(
         appearance: UICollectionLayoutListConfiguration.Appearance,
-        backgroundColor: UIColor? = nil,
-        showsSeparators: Bool = true
+        backgroundColor: UIColor? = nil
     ) {
         self.appearance = appearance
         self.backgroundColor = backgroundColor
-        self.showsSeparators = showsSeparators
     }
-    
+
     func asCollectionLayoutListConfiguration() -> UICollectionLayoutListConfiguration {
         var config = UICollectionLayoutListConfiguration(appearance: appearance)
         config.backgroundColor = backgroundColor
+        #if os(iOS)
         config.showsSeparators = showsSeparators
+        #endif
         return config
     }
 }

--- a/Sources/RibbonKit/List/RibbonListSectionConfiguration.swift
+++ b/Sources/RibbonKit/List/RibbonListSectionConfiguration.swift
@@ -10,6 +10,7 @@ public struct RibbonListSectionConfiguration: Hashable {
     public var sectionInsets: UIEdgeInsets
     public var headerInsets: UIEdgeInsets
     public var footerInsets: UIEdgeInsets
+    public var listConfiguration: RibbonListCollectionViewListConfiguration
 
     public init(
         layout: RibbonListSectionLayout,
@@ -17,7 +18,8 @@ public struct RibbonListSectionConfiguration: Hashable {
         interGroupSpacing: CGFloat = 6.0,
         sectionInsets: UIEdgeInsets = .zero,
         headerInsets: UIEdgeInsets = .zero,
-        footerInsets: UIEdgeInsets = .zero
+        footerInsets: UIEdgeInsets = .zero,
+        listConfiguration: RibbonListCollectionViewListConfiguration = .init(appearance: .plain)
     ) {
         self.layout = layout
         self.interItemSpacing = interItemSpacing
@@ -25,6 +27,7 @@ public struct RibbonListSectionConfiguration: Hashable {
         self.sectionInsets = sectionInsets
         self.headerInsets = headerInsets
         self.footerInsets = footerInsets
+        self.listConfiguration = listConfiguration
     }
 
     public static let `default` = RibbonListSectionConfiguration(layout: .horizontal(heightDimension: .absolute(80), itemWidthDimension: .absolute(80)))

--- a/Sources/RibbonKit/List/RibbonListSectionConfiguration.swift
+++ b/Sources/RibbonKit/List/RibbonListSectionConfiguration.swift
@@ -10,7 +10,6 @@ public struct RibbonListSectionConfiguration: Hashable {
     public var sectionInsets: UIEdgeInsets
     public var headerInsets: UIEdgeInsets
     public var footerInsets: UIEdgeInsets
-    public var listConfiguration: RibbonListCollectionViewListConfiguration
 
     public init(
         layout: RibbonListSectionLayout,
@@ -18,8 +17,7 @@ public struct RibbonListSectionConfiguration: Hashable {
         interGroupSpacing: CGFloat = 6.0,
         sectionInsets: UIEdgeInsets = .zero,
         headerInsets: UIEdgeInsets = .zero,
-        footerInsets: UIEdgeInsets = .zero,
-        listConfiguration: RibbonListCollectionViewListConfiguration = .init(appearance: .plain)
+        footerInsets: UIEdgeInsets = .zero
     ) {
         self.layout = layout
         self.interItemSpacing = interItemSpacing
@@ -27,7 +25,6 @@ public struct RibbonListSectionConfiguration: Hashable {
         self.sectionInsets = sectionInsets
         self.headerInsets = headerInsets
         self.footerInsets = footerInsets
-        self.listConfiguration = listConfiguration
     }
 
     public static let `default` = RibbonListSectionConfiguration(layout: .horizontal(heightDimension: .absolute(80), itemWidthDimension: .absolute(80)))

--- a/Sources/RibbonKit/List/RibbonListSectionLayout.swift
+++ b/Sources/RibbonKit/List/RibbonListSectionLayout.swift
@@ -4,7 +4,7 @@ import UIKit
 
 public struct RibbonListSectionLayout: Hashable {
 
-    public enum Orientation { case horizontal, vertical }
+    public enum Orientation { case horizontal, vertical, list }
 
     public let orientation: Orientation
     public let numberOfRows: Int
@@ -43,6 +43,15 @@ public struct RibbonListSectionLayout: Hashable {
             numberOfRows: numberOfRows,
             heightDimension: heightDimension,
             itemWidthDimensions: [itemWidthDimension]
+        )
+    }
+    
+    public static func list() -> RibbonListSectionLayout {
+        return .init(
+            orientation: .list,
+            numberOfRows: 1,
+            heightDimension: .fractionalHeight(1),
+            itemWidthDimensions: [.fractionalWidth(1)]
         )
     }
 

--- a/Sources/RibbonKit/List/RibbonListSectionLayout.swift
+++ b/Sources/RibbonKit/List/RibbonListSectionLayout.swift
@@ -4,7 +4,11 @@ import UIKit
 
 public struct RibbonListSectionLayout: Hashable {
 
-    public enum Orientation { case horizontal, vertical, list }
+    public enum Orientation: Hashable {
+        case horizontal
+        case vertical
+        case list(RibbonListCollectionViewListConfiguration)
+    }
 
     public let orientation: Orientation
     public let numberOfRows: Int
@@ -46,9 +50,9 @@ public struct RibbonListSectionLayout: Hashable {
         )
     }
     
-    public static func list() -> RibbonListSectionLayout {
+    public static func list(_ configuration: RibbonListCollectionViewListConfiguration) -> RibbonListSectionLayout {
         return .init(
-            orientation: .list,
+            orientation: .list(configuration),
             numberOfRows: 1,
             heightDimension: .fractionalHeight(1),
             itemWidthDimensions: [.fractionalWidth(1)]

--- a/Sources/RibbonKit/List/RibbonListView.swift
+++ b/Sources/RibbonKit/List/RibbonListView.swift
@@ -249,8 +249,14 @@ public class RibbonListView: UIView {
                 section.orthogonalScrollingBehavior = self.horizontalScrollingBehavior
             }
             else {
+                var listConfig: UICollectionLayoutListConfiguration = .init(appearance: .plain)
+
+                if case .list(let config) = configuration.layout.orientation {
+                    listConfig = config.asCollectionLayoutListConfiguration()
+                }
+
                 section = NSCollectionLayoutSection.list(
-                    using: configuration.listConfiguration.asCollectionLayoutListConfiguration(),
+                    using: listConfig,
                     layoutEnvironment: layoutEnvironment
                 )
             }

--- a/Sources/RibbonKit/List/RibbonListView.swift
+++ b/Sources/RibbonKit/List/RibbonListView.swift
@@ -205,10 +205,11 @@ public class RibbonListView: UIView {
 
     private func buildLayout() -> UICollectionViewCompositionalLayout {
         let layout = RibbonListViewCompositionalLayout {
-            [unowned self] sectionIndex, layoutEnvironment in
+            [unowned self] sectionIndex, layoutEnvironment in
             let configuration = self.delegate?.ribbonList(self, configurationForSectionAt: sectionIndex) ?? .default
 
-            let group: NSCollectionLayoutGroup
+            var group: NSCollectionLayoutGroup?
+            let section: NSCollectionLayoutSection
             if configuration.layout.orientation == .vertical {
                 let itemSize = NSCollectionLayoutSize(
                     widthDimension: .fractionalWidth(1),
@@ -225,7 +226,7 @@ public class RibbonListView: UIView {
                     count: configuration.layout.numberOfRows
                 )
             }
-            else {
+            else if configuration.layout.orientation == .horizontal {
                 let items: [NSCollectionLayoutItem] = (0..<configuration.layout.itemWidthDimensions.count).map { itemIndex in
                     let itemWidth = configuration.layout.itemWidthDimensions[itemIndex]
                     let itemSize = NSCollectionLayoutSize(
@@ -241,10 +242,19 @@ public class RibbonListView: UIView {
                 )
                 group = NSCollectionLayoutGroup.horizontal(layoutSize: itemGroupSize, subitems: items)
             }
-            group.interItemSpacing = .fixed(configuration.interItemSpacing)
 
-            let section = NSCollectionLayoutSection(group: group)
-            section.orthogonalScrollingBehavior = self.horizontalScrollingBehavior
+            if let group = group {
+                group.interItemSpacing = .fixed(configuration.interItemSpacing)
+                section = NSCollectionLayoutSection(group: group)
+                section.orthogonalScrollingBehavior = self.horizontalScrollingBehavior
+            }
+            else {
+                section = NSCollectionLayoutSection.list(
+                    using: configuration.listConfiguration.asCollectionLayoutListConfiguration(),
+                    layoutEnvironment: layoutEnvironment
+                )
+            }
+
             section.interGroupSpacing = configuration.interGroupSpacing
             section.contentInsets = .init(
                 top: configuration.sectionInsets.top,


### PR DESCRIPTION
This Pull request aim to extend support also to CompositionalLayout.list type.

I've made a few changes inside `buildLayout()` of `RibbonListView`.
Also created a new `RibbonListCollectionViewListConfiguration` to pass a custom UICollectionLayoutListConfiguration when using `.list` layout type.

Let me know what you think, as always, any suggestion/feedback is welcome!  