### PR TITLE
Do not reload header view for orientations faceUp and faceDown

### DIFF
--- a/Sources/RibbonKit/List/RibbonListView.swift
+++ b/Sources/RibbonKit/List/RibbonListView.swift
@@ -87,6 +87,11 @@ public class RibbonListView: UIView {
         collectionView.register(RibbonListReusableHostView.self, forSupplementaryViewOfKind: "header")
         return collectionView
     }()
+    
+    /// An array of unsupported orientations
+    ///
+    /// This property will be used to prevent header reload for unsupported UIDeviceOrientation
+    public var unsupportedOrientations: [UIDeviceOrientation] = []
 
     private var currentlyFocusedIndexPath: IndexPath?
 
@@ -124,6 +129,8 @@ public class RibbonListView: UIView {
 
     #if os(iOS)
     @objc private func deviceOrientationDidChange(_ notification: Notification) {
+        let orientation = UIDevice.current.orientation
+        guard !unsupportedOrientations.contains(orientation) else { return }
         reloadHeaderView()
     }
     #endif

--- a/Sources/RibbonKit/List/RibbonListView.swift
+++ b/Sources/RibbonKit/List/RibbonListView.swift
@@ -88,10 +88,12 @@ public class RibbonListView: UIView {
         return collectionView
     }()
     
+    #if os(iOS)
     /// An array of unsupported orientations
     ///
     /// This property will be used to prevent header reload for unsupported UIDeviceOrientation
     public var unsupportedOrientations: [UIDeviceOrientation] = []
+    #endif
 
     private var currentlyFocusedIndexPath: IndexPath?
 

--- a/Sources/RibbonKit/List/RibbonListView.swift
+++ b/Sources/RibbonKit/List/RibbonListView.swift
@@ -87,13 +87,6 @@ public class RibbonListView: UIView {
         collectionView.register(RibbonListReusableHostView.self, forSupplementaryViewOfKind: "header")
         return collectionView
     }()
-    
-    #if os(iOS)
-    /// An array of unsupported orientations
-    ///
-    /// This property will be used to prevent header reload for unsupported UIDeviceOrientation
-    public var unsupportedOrientations: [UIDeviceOrientation] = []
-    #endif
 
     private var currentlyFocusedIndexPath: IndexPath?
 
@@ -132,6 +125,7 @@ public class RibbonListView: UIView {
     #if os(iOS)
     @objc private func deviceOrientationDidChange(_ notification: Notification) {
         let orientation = UIDevice.current.orientation
+        let unsupportedOrientations: [UIDeviceOrientation] = [.faceUp, .faceDown]
         guard !unsupportedOrientations.contains(orientation) else { return }
         reloadHeaderView()
     }


### PR DESCRIPTION
To prevent reloadHeaderView() for unsupported orientations on iOS devices