### PR TITLE
Add .single orientation Layout

### DIFF
--- a/RibbonKit.xcodeproj/project.pbxproj
+++ b/RibbonKit.xcodeproj/project.pbxproj
@@ -20,7 +20,6 @@
 		3048262925B876FD001AFC2C /* RibbonListViewFocusUpdateContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3048262825B876FD001AFC2C /* RibbonListViewFocusUpdateContext.swift */; };
 		30B56F12273094AB006AB071 /* RibbonListSectionLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B56F11273094AB006AB071 /* RibbonListSectionLayout.swift */; };
 		30B56F142730A45D006AB071 /* RibbonListViewCompositionalLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B56F132730A45D006AB071 /* RibbonListViewCompositionalLayout.swift */; };
-		30B56F162730A493006AB071 /* RibbonListViewDiffableDataSourceSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B56F152730A493006AB071 /* RibbonListViewDiffableDataSourceSnapshot.swift */; };
 		30B56F182730A4A8006AB071 /* RibbonListViewDiffableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B56F172730A4A8006AB071 /* RibbonListViewDiffableDataSource.swift */; };
 		30B56F1A2730A54D006AB071 /* RibbonListViewScrollingBehaviour.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B56F192730A54D006AB071 /* RibbonListViewScrollingBehaviour.swift */; };
 		30BF400425B833E000BE8A98 /* Lorem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30BF400325B833E000BE8A98 /* Lorem.swift */; };
@@ -71,7 +70,6 @@
 		3048262825B876FD001AFC2C /* RibbonListViewFocusUpdateContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RibbonListViewFocusUpdateContext.swift; sourceTree = "<group>"; };
 		30B56F11273094AB006AB071 /* RibbonListSectionLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RibbonListSectionLayout.swift; sourceTree = "<group>"; };
 		30B56F132730A45D006AB071 /* RibbonListViewCompositionalLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RibbonListViewCompositionalLayout.swift; sourceTree = "<group>"; };
-		30B56F152730A493006AB071 /* RibbonListViewDiffableDataSourceSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RibbonListViewDiffableDataSourceSnapshot.swift; sourceTree = "<group>"; };
 		30B56F172730A4A8006AB071 /* RibbonListViewDiffableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RibbonListViewDiffableDataSource.swift; sourceTree = "<group>"; };
 		30B56F192730A54D006AB071 /* RibbonListViewScrollingBehaviour.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RibbonListViewScrollingBehaviour.swift; sourceTree = "<group>"; };
 		30BF400325B833E000BE8A98 /* Lorem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lorem.swift; sourceTree = "<group>"; };
@@ -194,7 +192,6 @@
 				30DFDD4B2721B42500EAAF87 /* RibbonListView.swift */,
 				30B56F192730A54D006AB071 /* RibbonListViewScrollingBehaviour.swift */,
 				30B56F172730A4A8006AB071 /* RibbonListViewDiffableDataSource.swift */,
-				30B56F152730A493006AB071 /* RibbonListViewDiffableDataSourceSnapshot.swift */,
 				3048262825B876FD001AFC2C /* RibbonListViewFocusUpdateContext.swift */,
 				30F07A2F24C867CF00BFFE5E /* RibbonListViewDelegate.swift */,
 				30D8E9992730507E00002793 /* RibbonListDimension.swift */,
@@ -420,7 +417,6 @@
 				30B56F12273094AB006AB071 /* RibbonListSectionLayout.swift in Sources */,
 				OBJ_25 /* UICollectionView+Reusable.swift in Sources */,
 				30D8E99A2730507E00002793 /* RibbonListDimension.swift in Sources */,
-				30B56F162730A493006AB071 /* RibbonListViewDiffableDataSourceSnapshot.swift in Sources */,
 				30DFDD4E2721B47C00EAAF87 /* RibbonListReusableHostView.swift in Sources */,
 				3044596324C7B15D0062BA54 /* RibbonListSectionConfiguration.swift in Sources */,
 				30B56F1A2730A54D006AB071 /* RibbonListViewScrollingBehaviour.swift in Sources */,

--- a/RibbonKit.xcodeproj/project.pbxproj
+++ b/RibbonKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0A2350F628522E6C0025CD1D /* RibbonListItemsConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2350F528522E6C0025CD1D /* RibbonListItemsConfiguration.swift */; };
 		0AC30F76278F20BE00ED8059 /* RibbonListCollectionViewListConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC30F75278F20BD00ED8059 /* RibbonListCollectionViewListConfiguration.swift */; };
 		303F475924CF6E7900763149 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 303F475824CF6E7900763149 /* Assets.xcassets */; };
 		303F475C24CF6E7900763149 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 303F475A24CF6E7900763149 /* LaunchScreen.storyboard */; };
@@ -60,6 +61,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0A2350F528522E6C0025CD1D /* RibbonListItemsConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RibbonListItemsConfiguration.swift; sourceTree = "<group>"; };
 		0AC30F75278F20BD00ED8059 /* RibbonListCollectionViewListConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RibbonListCollectionViewListConfiguration.swift; sourceTree = "<group>"; };
 		303F474F24CF6E7800763149 /* Example-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		303F475824CF6E7900763149 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -198,6 +200,7 @@
 				3044596224C7B15D0062BA54 /* RibbonListSectionConfiguration.swift */,
 				30B56F11273094AB006AB071 /* RibbonListSectionLayout.swift */,
 				30B56F132730A45D006AB071 /* RibbonListViewCompositionalLayout.swift */,
+				0A2350F528522E6C0025CD1D /* RibbonListItemsConfiguration.swift */,
 			);
 			path = List;
 			sourceTree = "<group>";
@@ -416,6 +419,7 @@
 				OBJ_24 /* ReusableView.swift in Sources */,
 				30B56F12273094AB006AB071 /* RibbonListSectionLayout.swift in Sources */,
 				OBJ_25 /* UICollectionView+Reusable.swift in Sources */,
+				0A2350F628522E6C0025CD1D /* RibbonListItemsConfiguration.swift in Sources */,
 				30D8E99A2730507E00002793 /* RibbonListDimension.swift in Sources */,
 				30DFDD4E2721B47C00EAAF87 /* RibbonListReusableHostView.swift in Sources */,
 				3044596324C7B15D0062BA54 /* RibbonListSectionConfiguration.swift in Sources */,

--- a/Shared/Data/ColorGroup.swift
+++ b/Shared/Data/ColorGroup.swift
@@ -63,6 +63,22 @@ extension ColorGroup: Hashable {
 extension ColorGroup {
     static let exampleGroups: [ColorGroup] = [
         ColorGroup(
+            headerTitle: "Monochrom-ish Colors",
+            footerTitle: "A range of blue colors to please your eyes. You can click on a cell to change its color.",
+            configuration:
+                RibbonListSectionConfiguration(
+                    layout: .single(
+                        heightDimension: .absolute(70),
+                        itemsConfiguration: ItemsConfiguration(
+                            phoneConfiguration: .init(portraitItems: 2, landscapeItems: 4),
+                            padConfiguration: .init(portraitItems: 4, landscapeItems: 8)
+                        )
+                    )
+                ),
+            hue: .monochrome,
+            luminosity: .light
+        ),
+        ColorGroup(
             headerTitle: "Blue-ish Colors",
             footerTitle: "A range of blue colors to please your eyes. You can click on a cell to change its color.",
             configuration:

--- a/Shared/UI/ViewController.swift
+++ b/Shared/UI/ViewController.swift
@@ -48,7 +48,7 @@ class ViewController: UIViewController {
         return list
     }()
 
-    typealias Snapshot = RibbonListViewDiffableDataSourceSnapshot<ColorGroup, ColorItem>
+    typealias Snapshot = NSDiffableDataSourceSnapshot<ColorGroup, ColorItem>
     typealias DataSource = RibbonListViewDiffableDataSource<ColorGroup, ColorItem>
 
     private lazy var dataSource: DataSource = {
@@ -109,7 +109,7 @@ class ViewController: UIViewController {
     }
 
     func applySnapshot() {
-        let snapshot = Snapshot()
+        var snapshot = Snapshot()
 
         snapshot.appendSections(groups)
         groups.forEach {

--- a/Sources/RibbonKit/List/RibbonListItemsConfiguration.swift
+++ b/Sources/RibbonKit/List/RibbonListItemsConfiguration.swift
@@ -1,6 +1,7 @@
 //  Copyright © 2021 Roman Blum. All rights reserved.
 
 import Foundation
+import CoreGraphics
 
 protocol ItemsConfigurable {
     var portraitItems: Int { get }
@@ -31,6 +32,7 @@ public struct ItemsConfiguration: Hashable {
     
     public var phoneConfiguration: PhoneItemsConfiguration
     public var padConfiguration: PadItemsConfiguration
+    public var aspectRatio: CGFloat
     
     static var `default` = ItemsConfiguration(phoneConfiguration: .init(), padConfiguration: .init())
 
@@ -40,5 +42,14 @@ public struct ItemsConfiguration: Hashable {
     ) {
         self.phoneConfiguration = phoneConfiguration
         self.padConfiguration = padConfiguration
+        self.aspectRatio = 0
+    }
+    
+    public init(
+        aspectRatio: CGFloat
+    ) {
+        self.phoneConfiguration = .init()
+        self.padConfiguration = .init()
+        self.aspectRatio = aspectRatio
     }
 }

--- a/Sources/RibbonKit/List/RibbonListItemsConfiguration.swift
+++ b/Sources/RibbonKit/List/RibbonListItemsConfiguration.swift
@@ -1,0 +1,44 @@
+//  Copyright © 2021 Roman Blum. All rights reserved.
+
+import Foundation
+
+protocol ItemsConfigurable {
+    var portraitItems: Int { get }
+    var landscapeItems: Int { get }
+}
+
+public struct ItemsConfiguration: Hashable {
+    
+    public struct PhoneItemsConfiguration: ItemsConfigurable, Hashable {
+        public let portraitItems: Int
+        public let landscapeItems: Int
+        
+        public init(portraitItems: Int = 1, landscapeItems: Int = 2) {
+            self.portraitItems = portraitItems
+            self.landscapeItems = landscapeItems
+        }
+    }
+    
+    public struct PadItemsConfiguration: ItemsConfigurable, Hashable {
+        public let portraitItems: Int
+        public let landscapeItems: Int
+        
+        public init(portraitItems: Int = 2, landscapeItems: Int = 4) {
+            self.portraitItems = portraitItems
+            self.landscapeItems = landscapeItems
+        }
+    }
+    
+    public var phoneConfiguration: PhoneItemsConfiguration
+    public var padConfiguration: PadItemsConfiguration
+    
+    static var `default` = ItemsConfiguration(phoneConfiguration: .init(), padConfiguration: .init())
+
+    public init(
+        phoneConfiguration: PhoneItemsConfiguration,
+        padConfiguration: PadItemsConfiguration
+    ) {
+        self.phoneConfiguration = phoneConfiguration
+        self.padConfiguration = padConfiguration
+    }
+}

--- a/Sources/RibbonKit/List/RibbonListSectionLayout.swift
+++ b/Sources/RibbonKit/List/RibbonListSectionLayout.swift
@@ -8,12 +8,14 @@ public struct RibbonListSectionLayout: Hashable {
         case horizontal
         case vertical
         case list(RibbonListCollectionViewListConfiguration)
+        case single
     }
-
+    
     public let orientation: Orientation
     public let numberOfRows: Int
     public let heightDimension: RibbonListDimension
     public let itemWidthDimensions: [RibbonListDimension]
+    public var itemsConfiguration: ItemsConfiguration
 
     public static func horizontal(
         heightDimension: RibbonListDimension,
@@ -23,7 +25,8 @@ public struct RibbonListSectionLayout: Hashable {
             orientation: .horizontal,
             numberOfRows: 1,
             heightDimension: heightDimension,
-            itemWidthDimensions: itemWidthDimensions.isEmpty ? [.estimated(80)] : itemWidthDimensions
+            itemWidthDimensions: itemWidthDimensions.isEmpty ? [.estimated(80)] : itemWidthDimensions,
+            itemsConfiguration: .default
         )
     }
 
@@ -46,7 +49,8 @@ public struct RibbonListSectionLayout: Hashable {
             orientation: .vertical,
             numberOfRows: numberOfRows,
             heightDimension: heightDimension,
-            itemWidthDimensions: [itemWidthDimension]
+            itemWidthDimensions: [itemWidthDimension],
+            itemsConfiguration: .default
         )
     }
     
@@ -55,7 +59,28 @@ public struct RibbonListSectionLayout: Hashable {
             orientation: .list(configuration),
             numberOfRows: 1,
             heightDimension: .fractionalHeight(1),
-            itemWidthDimensions: [.fractionalWidth(1)]
+            itemWidthDimensions: [.fractionalWidth(1)],
+            itemsConfiguration: .default
+        )
+    }
+    
+    /// Create a new section with an horizontal layout, each Row is made up of items and you cannot scroll horizontally.
+    /// Items are displayed on new lines. (For example: every 3 items you'll have a new row)
+    /// - Parameters:
+    ///   - heightDimension: Height of each row
+    ///   - portraitItems: Number of items in portrait
+    ///   - landscapeItems: Number of items in landscape
+    /// - Returns: New horizontal RibbonListSectionLayout
+    public static func single(
+        heightDimension: RibbonListDimension,
+        itemsConfiguration: ItemsConfiguration
+    ) -> RibbonListSectionLayout {
+        return .init(
+            orientation: .single,
+            numberOfRows: 1,
+            heightDimension: heightDimension,
+            itemWidthDimensions: [.estimated(1)],
+            itemsConfiguration: itemsConfiguration
         )
     }
 

--- a/Sources/RibbonKit/List/RibbonListSectionLayout.swift
+++ b/Sources/RibbonKit/List/RibbonListSectionLayout.swift
@@ -8,14 +8,13 @@ public struct RibbonListSectionLayout: Hashable {
         case horizontal
         case vertical
         case list(RibbonListCollectionViewListConfiguration)
-        case single
+        case single(ItemsConfiguration)
     }
     
     public let orientation: Orientation
     public let numberOfRows: Int
     public let heightDimension: RibbonListDimension
     public let itemWidthDimensions: [RibbonListDimension]
-    public var itemsConfiguration: ItemsConfiguration
 
     public static func horizontal(
         heightDimension: RibbonListDimension,
@@ -25,8 +24,7 @@ public struct RibbonListSectionLayout: Hashable {
             orientation: .horizontal,
             numberOfRows: 1,
             heightDimension: heightDimension,
-            itemWidthDimensions: itemWidthDimensions.isEmpty ? [.estimated(80)] : itemWidthDimensions,
-            itemsConfiguration: .default
+            itemWidthDimensions: itemWidthDimensions.isEmpty ? [.estimated(80)] : itemWidthDimensions
         )
     }
 
@@ -49,8 +47,7 @@ public struct RibbonListSectionLayout: Hashable {
             orientation: .vertical,
             numberOfRows: numberOfRows,
             heightDimension: heightDimension,
-            itemWidthDimensions: [itemWidthDimension],
-            itemsConfiguration: .default
+            itemWidthDimensions: [itemWidthDimension]
         )
     }
     
@@ -59,28 +56,25 @@ public struct RibbonListSectionLayout: Hashable {
             orientation: .list(configuration),
             numberOfRows: 1,
             heightDimension: .fractionalHeight(1),
-            itemWidthDimensions: [.fractionalWidth(1)],
-            itemsConfiguration: .default
+            itemWidthDimensions: [.fractionalWidth(1)]
         )
     }
-    
+
     /// Create a new section with an horizontal layout, each Row is made up of items and you cannot scroll horizontally.
     /// Items are displayed on new lines. (For example: every 3 items you'll have a new row)
     /// - Parameters:
     ///   - heightDimension: Height of each row
-    ///   - portraitItems: Number of items in portrait
-    ///   - landscapeItems: Number of items in landscape
+    ///   - itemsConfiguration: Configuration of items to be displayed
     /// - Returns: New horizontal RibbonListSectionLayout
     public static func single(
         heightDimension: RibbonListDimension,
         itemsConfiguration: ItemsConfiguration
     ) -> RibbonListSectionLayout {
         return .init(
-            orientation: .single,
+            orientation: .single(itemsConfiguration),
             numberOfRows: 1,
             heightDimension: heightDimension,
-            itemWidthDimensions: [.estimated(1)],
-            itemsConfiguration: itemsConfiguration
+            itemWidthDimensions: []
         )
     }
 

--- a/Sources/RibbonKit/List/RibbonListView.swift
+++ b/Sources/RibbonKit/List/RibbonListView.swift
@@ -90,6 +90,8 @@ public class RibbonListView: UIView {
 
     private var currentlyFocusedIndexPath: IndexPath?
 
+    private var screenSize: CGSize = UIScreen.main.bounds.size
+    
     /// Initializes and returns a ribbon list having the given frame.
     ///
     /// - Parameters:
@@ -291,10 +293,13 @@ public class RibbonListView: UIView {
                 else {
                     let widthDimension: RibbonListDimension = .absolute(configuration.layout.heightDimension.value * config.aspectRatio)
                     let groupSize = NSCollectionLayoutSize(
-                        widthDimension: widthDimension.uiDimension,
+                        widthDimension: .fractionalWidth(1.0),
                         heightDimension: configuration.layout.heightDimension.uiDimension)
-                    let subItemsCount = CGFloat(UIScreen.main.bounds.width / widthDimension.value).rounded()
-                    group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: Array(repeating: item, count: Int(subItemsCount)))
+                    
+                    if let self = self {
+                        let subItemsCount = self.getScreenWidth() / widthDimension.value
+                        group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: Int(subItemsCount.rounded()))
+                    }
                 }
             }
 
@@ -303,8 +308,7 @@ public class RibbonListView: UIView {
                 section = NSCollectionLayoutSection(group: group)
                 
                 section.orthogonalScrollingBehavior = self?.horizontalScrollingBehavior ?? .continuousGroupLeadingBoundary
-                if case .single(let config) = configuration.layout.orientation,
-                    config.aspectRatio == 0 {
+                if case .single = configuration.layout.orientation {
                     section.orthogonalScrollingBehavior = .none
                 }
             }
@@ -358,6 +362,14 @@ public class RibbonListView: UIView {
         }
         layout.delegate = self
         return layout
+    }
+    
+    private func getScreenWidth() -> CGFloat {
+        if UIDevice.current.orientation.isPortrait {
+            return screenSize.width < screenSize.height ? screenSize.width : screenSize.height
+        } else {
+            return screenSize.width > screenSize.height ? screenSize.width : screenSize.height
+        }
     }
 }
 

--- a/Sources/RibbonKit/List/RibbonListView.swift
+++ b/Sources/RibbonKit/List/RibbonListView.swift
@@ -87,6 +87,11 @@ public class RibbonListView: UIView {
         collectionView.register(RibbonListReusableHostView.self, forSupplementaryViewOfKind: "header")
         return collectionView
     }()
+    
+    /// An array of unsupported orientations
+    ///
+    /// This property will be used to prevent header reload for unsupported UIDeviceOrientation
+    public var unsupportedOrientations: [UIDeviceOrientation] = []
 
     private var currentlyFocusedIndexPath: IndexPath?
 
@@ -124,6 +129,8 @@ public class RibbonListView: UIView {
 
     #if os(iOS)
     @objc private func deviceOrientationDidChange(_ notification: Notification) {
+        let orientation = UIDevice.current.orientation
+        guard !unsupportedOrientations.contains(orientation) else { return }
         reloadHeaderView()
     }
     #endif

--- a/Sources/RibbonKit/List/RibbonListView.swift
+++ b/Sources/RibbonKit/List/RibbonListView.swift
@@ -266,11 +266,35 @@ public class RibbonListView: UIView {
                 )
                 group = NSCollectionLayoutGroup.horizontal(layoutSize: itemGroupSize, subitems: items)
             }
+            else if configuration.layout.orientation == .single {
+                let itemSize = NSCollectionLayoutSize(
+                    widthDimension: .fractionalWidth(1.0),
+                    heightDimension: .fractionalHeight(1.0)
+                )
+                let item = NSCollectionLayoutItem(layoutSize: itemSize)
+                
+                var numberOfItems = 0
+                let currentDevice = UIDevice.current
+                let itemsConfig = configuration.layout.itemsConfiguration
+                if currentDevice.userInterfaceIdiom == .phone {
+                    numberOfItems = currentDevice.orientation.isPortrait ? itemsConfig.phoneConfiguration.portraitItems : itemsConfig.phoneConfiguration.landscapeItems
+                } else if currentDevice.userInterfaceIdiom == .pad {
+                    numberOfItems = currentDevice.orientation.isPortrait ? itemsConfig.padConfiguration.portraitItems : itemsConfig.padConfiguration.landscapeItems
+                }
+                let fraction = CGFloat(1.0 / Double(numberOfItems))
+                let groupSize = NSCollectionLayoutSize(
+                    widthDimension: .fractionalWidth(1.0),
+                    heightDimension: configuration.layout.heightDimension.uiDimension)
+                group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: numberOfItems)
+            }
 
             if let group = group {
                 group.interItemSpacing = .fixed(configuration.interItemSpacing)
                 section = NSCollectionLayoutSection(group: group)
-                section.orthogonalScrollingBehavior = self?.horizontalScrollingBehavior ?? .continuousGroupLeadingBoundary
+                
+                if configuration.layout.orientation != .single {
+                    section.orthogonalScrollingBehavior = self?.horizontalScrollingBehavior ?? .continuousGroupLeadingBoundary
+                }
             }
             else {
                 var listConfig: UICollectionLayoutListConfiguration = .init(appearance: .plain)

--- a/Sources/RibbonKit/List/RibbonListView.swift
+++ b/Sources/RibbonKit/List/RibbonListView.swift
@@ -88,10 +88,12 @@ public class RibbonListView: UIView {
         return collectionView
     }()
     
+    #if os(iOS)
     /// An array of unsupported orientations
     ///
     /// This property will be used to prevent header reload for unsupported UIDeviceOrientation
     public var unsupportedOrientations: [UIDeviceOrientation] = []
+    #endif
 
     private var currentlyFocusedIndexPath: IndexPath?
 

--- a/Sources/RibbonKit/List/RibbonListView.swift
+++ b/Sources/RibbonKit/List/RibbonListView.swift
@@ -87,13 +87,6 @@ public class RibbonListView: UIView {
         collectionView.register(RibbonListReusableHostView.self, forSupplementaryViewOfKind: "header")
         return collectionView
     }()
-    
-    #if os(iOS)
-    /// An array of unsupported orientations
-    ///
-    /// This property will be used to prevent header reload for unsupported UIDeviceOrientation
-    public var unsupportedOrientations: [UIDeviceOrientation] = []
-    #endif
 
     private var currentlyFocusedIndexPath: IndexPath?
 
@@ -132,6 +125,7 @@ public class RibbonListView: UIView {
     #if os(iOS)
     @objc private func deviceOrientationDidChange(_ notification: Notification) {
         let orientation = UIDevice.current.orientation
+        let unsupportedOrientations: [UIDeviceOrientation] = [.faceUp, .faceDown]
         guard !unsupportedOrientations.contains(orientation) else { return }
         reloadHeaderView()
     }


### PR DESCRIPTION
Added a new .single orientation layout to arrange items horizontally to fit the entire width available, without the possibility to scroll off screen.

![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-06-09 at 15 25 49](https://user-images.githubusercontent.com/3455711/172861683-3cf1cfe0-c615-4939-8c22-58dde48934b8.png)
![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-06-09 at 15 25 46](https://user-images.githubusercontent.com/3455711/172861686-fa453fef-295c-4d36-be98-006a7d4f3689.png)

![Simulator Screen Shot - iPad mini (6th generation) - 2022-06-09 at 15 26 23](https://user-images.githubusercontent.com/3455711/172861677-df46219a-4f3f-415a-a4ad-a4abc30c6df9.png)
![Simulator Screen Shot - iPad mini (6th generation) - 2022-06-09 at 15 26 25](https://user-images.githubusercontent.com/3455711/172861665-d10f197b-2e1c-44d1-a919-4eedc3e7905f.png)

In monochrom-ish you can find the result.
