### PR TITLE
Add proposedIdentifier to ContextMenuConfiguration Delegate Method

### DIFF
--- a/Sources/RibbonKit/List/RibbonListView.swift
+++ b/Sources/RibbonKit/List/RibbonListView.swift
@@ -479,28 +479,18 @@ extension RibbonListView: UICollectionViewDelegate {
         _ collectionView: UICollectionView,
         previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration
     ) -> UITargetedPreview? {
-        delegate?.ribbonList(self, previewForHighlightingContextMenuWithConfiguration: configuration) ?? makeTargetedPreview(for: configuration)
+        delegate?.ribbonList(self, previewForHighlightingContextMenuWithConfiguration: configuration)
     }
 
-    /** Called when the interaction is about to dismiss. Return a UITargetedPreview describing the desired dismissal target.
+    /**
+     Called when the interaction is about to dismiss. Return a UITargetedPreview describing the desired dismissal target.
         The interaction will animate the presented menu to the target. Use this to customize the dismissal animation.
     */
     public func collectionView(
         _ collectionView: UICollectionView,
         previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration
     ) -> UITargetedPreview? {
-        return delegate?.ribbonList(self, previewForDismissingContextMenuWithConfiguration: configuration) ?? makeTargetedPreview(for: configuration)
-    }
-
-    private func makeTargetedPreview(for configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
-        // Ensure we can get the expected identifier.
-        guard let configIdentifier = configuration.identifier as? ContextMenuIdentifier else { return nil }
-        
-        let indexPath = IndexPath(row: configIdentifier.row, section: configIdentifier.section)
-        // Get the cell for the index of the model.
-        guard let cell = collectionView.cellForItem(at: indexPath) else { return nil }
-        
-        return UITargetedPreview(view: cell.contentView, parameters: UIPreviewParameters())
+        delegate?.ribbonList(self, previewForDismissingContextMenuWithConfiguration: configuration)
     }
     #endif
 }

--- a/Sources/RibbonKit/List/RibbonListView.swift
+++ b/Sources/RibbonKit/List/RibbonListView.swift
@@ -500,10 +500,7 @@ extension RibbonListView: UICollectionViewDelegate {
         // Get the cell for the index of the model.
         guard let cell = collectionView.cellForItem(at: indexPath) else { return nil }
         
-        let parameters = UIPreviewParameters()
-//            parameters.backgroundColor = .clear
-        
-        return UITargetedPreview(view: cell.contentView, parameters: parameters)
+        return UITargetedPreview(view: cell.contentView, parameters: UIPreviewParameters())
     }
     #endif
 }

--- a/Sources/RibbonKit/List/RibbonListViewDelegate.swift
+++ b/Sources/RibbonKit/List/RibbonListViewDelegate.swift
@@ -175,7 +175,24 @@ public protocol RibbonListViewDelegate: AnyObject {
     /// - Returns: A context menu configuration for the indexPath.
     func ribbonList(_ ribbonList: RibbonListView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint, proposedIdentifier: ContextMenuIdentifier) -> UIContextMenuConfiguration?
     
+    /// Returns a UITargetedPreview that will be used as a preview when presenting a context menu, overriding the default preview the collection view created
+    ///
+    /// Use this method to tell the delegate that the user has requested a preview of view for the item that requested a context menu presentation.
+    ///
+    /// - Parameters:
+    ///     - ribbonList: The ribbon list containing the item.
+    ///     - configuration: The context menu configuration.
+    /// - Returns: A view to override the default preview the collection view created
     func ribbonList(_ ribbonList: RibbonListView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview?
+
+    /// Returns a UITargetedPreview that will be used as a preview when dismissing a context menu, overriding the default preview the collection view created
+    ///
+    /// Use this method to tell the delegate that the user has requested a preview of view for the item that requested a context menu presentation.
+    ///
+    /// - Parameters:
+    ///     - ribbonList: The ribbon list containing the item.
+    ///     - configuration: The context menu configuration.
+    /// - Returns: A view to override the default preview the collection view created
     func ribbonList(_ ribbonList: RibbonListView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview?
     #endif
 }

--- a/Sources/RibbonKit/List/RibbonListViewDelegate.swift
+++ b/Sources/RibbonKit/List/RibbonListViewDelegate.swift
@@ -173,7 +173,10 @@ public protocol RibbonListViewDelegate: AnyObject {
     ///     - indexPath: The index path of the item.
     ///     - point: The location of the interaction in the ribbon list's coordinate space.
     /// - Returns: A context menu configuration for the indexPath.
-    func ribbonList(_ ribbonList: RibbonListView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration?
+    func ribbonList(_ ribbonList: RibbonListView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint, proposedIdentifier: ContextMenuIdentifier) -> UIContextMenuConfiguration?
+    
+    func ribbonList(_ ribbonList: RibbonListView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview?
+    func ribbonList(_ ribbonList: RibbonListView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview?
     #endif
 }
 
@@ -200,6 +203,8 @@ extension RibbonListViewDelegate {
     public func ribbonListDidEndDecelerating(_ ribbonList: RibbonListView) { }
 
     #if os(iOS)
-    public func ribbonList(_ ribbonList: RibbonListView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? { nil }
+    public func ribbonList(_ ribbonList: RibbonListView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint, proposedIdentifier: ContextMenuIdentifier) -> UIContextMenuConfiguration? { nil }
+    public func ribbonList(_ ribbonList: RibbonListView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? { nil }
+    public func ribbonList(_ ribbonList: RibbonListView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? { nil }
     #endif
 }

--- a/Sources/RibbonKit/List/RibbonListViewDelegate.swift
+++ b/Sources/RibbonKit/List/RibbonListViewDelegate.swift
@@ -183,6 +183,25 @@ public protocol RibbonListViewDelegate: AnyObject {
     ///     - ribbonList: The ribbon list containing the item.
     ///     - configuration: The context menu configuration.
     /// - Returns: A view to override the default preview the collection view created
+    /// Example:
+    /// ```swift
+    ///   func ribbonList(_ ribbonList: RibbonListView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+    ///        // Ensure we can get the expected identifier.
+    ///        // Use the identifier to get the UICollectionViewCell that requested context menu presentation
+    ///        guard let configIdentifier = configuration.identifier as? ContextMenuIdentifier else { return nil }
+    ///
+    ///        let indexPath = IndexPath(row: configIdentifier.row, section: configIdentifier.section)
+    ///        // Get the cell for the index of the model.
+    ///        guard let cell = collectionView.cellForItem(at: indexPath) else { return nil }
+    ///
+    ///        let parameters = UIPreviewParameters()
+    ///        let visibleRect = cell.contentView.bounds.insetBy(dx: -10, dy: -10)
+    ///        let visiblePath = UIBezierPath(roundedRect: visibleRect, cornerRadius: 20.0)
+    ///        parameters.visiblePath = visiblePath
+    ///        parameters.backgroundColor = UIColor.systemTeal
+    ///        return UITargetedPreview(view: cell.contentView, parameters: parameters)
+    ///    }
+    /// ```
     func ribbonList(_ ribbonList: RibbonListView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview?
 
     /// Returns a UITargetedPreview that will be used as a preview when dismissing a context menu, overriding the default preview the collection view created
@@ -193,6 +212,26 @@ public protocol RibbonListViewDelegate: AnyObject {
     ///     - ribbonList: The ribbon list containing the item.
     ///     - configuration: The context menu configuration.
     /// - Returns: A view to override the default preview the collection view created
+    ///
+    ///  Example:
+    /// ```swift
+    ///   func ribbonList(_ ribbonList: RibbonListView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+    ///        // Ensure we can get the expected identifier.
+    ///        // Use the identifier to get the UICollectionViewCell that requested context menu presentation
+    ///        guard let configIdentifier = configuration.identifier as? ContextMenuIdentifier else { return nil }
+    ///
+    ///        let indexPath = IndexPath(row: configIdentifier.row, section: configIdentifier.section)
+    ///        // Get the cell for the index of the model.
+    ///        guard let cell = collectionView.cellForItem(at: indexPath) else { return nil }
+    ///
+    ///        let parameters = UIPreviewParameters()
+    ///        let visibleRect = cell.contentView.bounds.insetBy(dx: -10, dy: -10)
+    ///        let visiblePath = UIBezierPath(roundedRect: visibleRect, cornerRadius: 20.0)
+    ///        parameters.visiblePath = visiblePath
+    ///        parameters.backgroundColor = UIColor.systemTeal
+    ///        return UITargetedPreview(view: cell.contentView, parameters: parameters)
+    ///    }
+    /// ```
     func ribbonList(_ ribbonList: RibbonListView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview?
     #endif
 }


### PR DESCRIPTION
the `func ribbonList(_ ribbonList:contextMenuConfigurationForItemAt indexPath:point:proposedIdentifier:) -> UIContextMenuConfiguration?` delegate method has been updated to provide the `proposedIdentifier` parameter to those that implement it. This new parameter is needed to create a ContextMenuConfiguration object, in order to prevent a visual bug which resulted in making the cell whose context menu was displayed, to disappear shortly, and then appear again.

In addition, two other delegate methods have been added and documented to the RibbonListViewDelegate, to allow the package users to customize the view to be used when a cell is long-pressed (highlighted right before the context menu appears), and when the context menu is being dismissed (allowing a custom animation to be implemented on context menu closing.