### PR TITLE
Managing Context Menus Presentation/Dismissal And Providing a preview-tapped Handler to Class Users

### DIFF
--- a/Sources/RibbonKit/List/RibbonListView.swift
+++ b/Sources/RibbonKit/List/RibbonListView.swift
@@ -479,28 +479,18 @@ extension RibbonListView: UICollectionViewDelegate {
         _ collectionView: UICollectionView,
         previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration
     ) -> UITargetedPreview? {
-        delegate?.ribbonList(self, previewForHighlightingContextMenuWithConfiguration: configuration) ?? makeTargetedPreview(for: configuration)
+        delegate?.ribbonList(self, previewForHighlightingContextMenuWithConfiguration: configuration)
     }
 
-    /** Called when the interaction is about to dismiss. Return a UITargetedPreview describing the desired dismissal target.
+    /**
+     Called when the interaction is about to dismiss. Return a UITargetedPreview describing the desired dismissal target.
         The interaction will animate the presented menu to the target. Use this to customize the dismissal animation.
     */
     public func collectionView(
         _ collectionView: UICollectionView,
         previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration
     ) -> UITargetedPreview? {
-        return delegate?.ribbonList(self, previewForDismissingContextMenuWithConfiguration: configuration) ?? makeTargetedPreview(for: configuration)
-    }
-
-    private func makeTargetedPreview(for configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
-        // Ensure we can get the expected identifier.
-        guard let configIdentifier = configuration.identifier as? ContextMenuIdentifier else { return nil }
-        
-        let indexPath = IndexPath(row: configIdentifier.row, section: configIdentifier.section)
-        // Get the cell for the index of the model.
-        guard let cell = collectionView.cellForItem(at: indexPath) else { return nil }
-        
-        return UITargetedPreview(view: cell.contentView, parameters: UIPreviewParameters())
+        delegate?.ribbonList(self, previewForDismissingContextMenuWithConfiguration: configuration)
     }
     #endif
 }

--- a/Sources/RibbonKit/List/RibbonListView.swift
+++ b/Sources/RibbonKit/List/RibbonListView.swift
@@ -500,10 +500,7 @@ extension RibbonListView: UICollectionViewDelegate {
         // Get the cell for the index of the model.
         guard let cell = collectionView.cellForItem(at: indexPath) else { return nil }
         
-        let parameters = UIPreviewParameters()
-//            parameters.backgroundColor = .clear
-        
-        return UITargetedPreview(view: cell.contentView, parameters: parameters)
+        return UITargetedPreview(view: cell.contentView, parameters: UIPreviewParameters())
     }
     #endif
 }

--- a/Sources/RibbonKit/List/RibbonListViewDelegate.swift
+++ b/Sources/RibbonKit/List/RibbonListViewDelegate.swift
@@ -173,7 +173,7 @@ public protocol RibbonListViewDelegate: AnyObject {
     ///     - indexPath: The index path of the item.
     ///     - point: The location of the interaction in the ribbon list's coordinate space.
     /// - Returns: A context menu configuration for the indexPath.
-    func ribbonList(_ ribbonList: RibbonListView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint, proposedIdentifier: ContextMenuIdentifier) -> UIContextMenuConfiguration?
+    func ribbonList(_ ribbonList: RibbonListView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration?
     
     /// Returns a UITargetedPreview that will be used as a preview when presenting a context menu, overriding the default preview the collection view created
     ///
@@ -185,7 +185,7 @@ public protocol RibbonListViewDelegate: AnyObject {
     /// - Returns: A view to override the default preview the collection view created
     /// Example:
     /// ```swift
-    ///   func ribbonList(_ ribbonList: RibbonListView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+    ///   func ribbonList(_ ribbonList: RibbonListView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration, at: IndexPath) -> UITargetedPreview? {
     ///        // Ensure we can get the expected identifier.
     ///        // Use the identifier to get the UICollectionViewCell that requested context menu presentation
     ///        guard let configIdentifier = configuration.identifier as? ContextMenuIdentifier else { return nil }
@@ -202,7 +202,7 @@ public protocol RibbonListViewDelegate: AnyObject {
     ///        return UITargetedPreview(view: cell.contentView, parameters: parameters)
     ///    }
     /// ```
-    func ribbonList(_ ribbonList: RibbonListView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview?
+    func ribbonList(_ ribbonList: RibbonListView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration, at: IndexPath) -> UITargetedPreview?
 
     /// Returns a UITargetedPreview that will be used as a preview when dismissing a context menu, overriding the default preview the collection view created
     ///
@@ -215,7 +215,7 @@ public protocol RibbonListViewDelegate: AnyObject {
     ///
     ///  Example:
     /// ```swift
-    ///   func ribbonList(_ ribbonList: RibbonListView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+    ///   func ribbonList(_ ribbonList: RibbonListView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration, at: IndexPath) -> UITargetedPreview? {
     ///        // Ensure we can get the expected identifier.
     ///        // Use the identifier to get the UICollectionViewCell that requested context menu presentation
     ///        guard let configIdentifier = configuration.identifier as? ContextMenuIdentifier else { return nil }
@@ -232,7 +232,9 @@ public protocol RibbonListViewDelegate: AnyObject {
     ///        return UITargetedPreview(view: cell.contentView, parameters: parameters)
     ///    }
     /// ```
-    func ribbonList(_ ribbonList: RibbonListView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview?
+    func ribbonList(_ ribbonList: RibbonListView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration, at: IndexPath) -> UITargetedPreview?
+    func ribbonList(_ ribbonList: RibbonListView, willPerformPreviewActionForMenuWith configuration: UIContextMenuConfiguration, at indexPath: IndexPath, animator: UIContextMenuInteractionCommitAnimating)
+    func ribbonListContextMenuPreviewBackgroundColor(_ ribbonList: RibbonListView, forItemAt indexPath: IndexPath) -> UIColor?
     #endif
 }
 
@@ -259,8 +261,10 @@ extension RibbonListViewDelegate {
     public func ribbonListDidEndDecelerating(_ ribbonList: RibbonListView) { }
 
     #if os(iOS)
-    public func ribbonList(_ ribbonList: RibbonListView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint, proposedIdentifier: ContextMenuIdentifier) -> UIContextMenuConfiguration? { nil }
-    public func ribbonList(_ ribbonList: RibbonListView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? { nil }
-    public func ribbonList(_ ribbonList: RibbonListView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? { nil }
+    public func ribbonList(_ ribbonList: RibbonListView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? { nil }
+    public func ribbonList(_ ribbonList: RibbonListView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration, at: IndexPath) -> UITargetedPreview? { nil }
+    public func ribbonList(_ ribbonList: RibbonListView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration, at: IndexPath) -> UITargetedPreview? { nil }
+    public func ribbonList(_ ribbonList: RibbonListView, willPerformPreviewActionForMenuWith configuration: UIContextMenuConfiguration, at indexPath: IndexPath, animator: UIContextMenuInteractionCommitAnimating) {}
+    public func ribbonListContextMenuPreviewBackgroundColor(_ ribbonList: RibbonListView, forItemAt indexPath: IndexPath) -> UIColor? { nil }
     #endif
 }

--- a/Sources/RibbonKit/List/RibbonListViewDelegate.swift
+++ b/Sources/RibbonKit/List/RibbonListViewDelegate.swift
@@ -175,7 +175,24 @@ public protocol RibbonListViewDelegate: AnyObject {
     /// - Returns: A context menu configuration for the indexPath.
     func ribbonList(_ ribbonList: RibbonListView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint, proposedIdentifier: ContextMenuIdentifier) -> UIContextMenuConfiguration?
     
+    /// Returns a UITargetedPreview that will be used as a preview when presenting a context menu, overriding the default preview the collection view created
+    ///
+    /// Use this method to tell the delegate that the user has requested a preview of view for the item that requested a context menu presentation.
+    ///
+    /// - Parameters:
+    ///     - ribbonList: The ribbon list containing the item.
+    ///     - configuration: The context menu configuration.
+    /// - Returns: A view to override the default preview the collection view created
     func ribbonList(_ ribbonList: RibbonListView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview?
+
+    /// Returns a UITargetedPreview that will be used as a preview when dismissing a context menu, overriding the default preview the collection view created
+    ///
+    /// Use this method to tell the delegate that the user has requested a preview of view for the item that requested a context menu presentation.
+    ///
+    /// - Parameters:
+    ///     - ribbonList: The ribbon list containing the item.
+    ///     - configuration: The context menu configuration.
+    /// - Returns: A view to override the default preview the collection view created
     func ribbonList(_ ribbonList: RibbonListView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview?
     #endif
 }

--- a/Sources/RibbonKit/List/RibbonListViewDelegate.swift
+++ b/Sources/RibbonKit/List/RibbonListViewDelegate.swift
@@ -173,7 +173,10 @@ public protocol RibbonListViewDelegate: AnyObject {
     ///     - indexPath: The index path of the item.
     ///     - point: The location of the interaction in the ribbon list's coordinate space.
     /// - Returns: A context menu configuration for the indexPath.
-    func ribbonList(_ ribbonList: RibbonListView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration?
+    func ribbonList(_ ribbonList: RibbonListView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint, proposedIdentifier: ContextMenuIdentifier) -> UIContextMenuConfiguration?
+    
+    func ribbonList(_ ribbonList: RibbonListView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview?
+    func ribbonList(_ ribbonList: RibbonListView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview?
     #endif
 }
 
@@ -200,6 +203,8 @@ extension RibbonListViewDelegate {
     public func ribbonListDidEndDecelerating(_ ribbonList: RibbonListView) { }
 
     #if os(iOS)
-    public func ribbonList(_ ribbonList: RibbonListView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? { nil }
+    public func ribbonList(_ ribbonList: RibbonListView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint, proposedIdentifier: ContextMenuIdentifier) -> UIContextMenuConfiguration? { nil }
+    public func ribbonList(_ ribbonList: RibbonListView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? { nil }
+    public func ribbonList(_ ribbonList: RibbonListView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? { nil }
     #endif
 }

--- a/Sources/RibbonKit/List/RibbonListViewDelegate.swift
+++ b/Sources/RibbonKit/List/RibbonListViewDelegate.swift
@@ -183,6 +183,25 @@ public protocol RibbonListViewDelegate: AnyObject {
     ///     - ribbonList: The ribbon list containing the item.
     ///     - configuration: The context menu configuration.
     /// - Returns: A view to override the default preview the collection view created
+    /// Example:
+    /// ```swift
+    ///   func ribbonList(_ ribbonList: RibbonListView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+    ///        // Ensure we can get the expected identifier.
+    ///        // Use the identifier to get the UICollectionViewCell that requested context menu presentation
+    ///        guard let configIdentifier = configuration.identifier as? ContextMenuIdentifier else { return nil }
+    ///
+    ///        let indexPath = IndexPath(row: configIdentifier.row, section: configIdentifier.section)
+    ///        // Get the cell for the index of the model.
+    ///        guard let cell = collectionView.cellForItem(at: indexPath) else { return nil }
+    ///
+    ///        let parameters = UIPreviewParameters()
+    ///        let visibleRect = cell.contentView.bounds.insetBy(dx: -10, dy: -10)
+    ///        let visiblePath = UIBezierPath(roundedRect: visibleRect, cornerRadius: 20.0)
+    ///        parameters.visiblePath = visiblePath
+    ///        parameters.backgroundColor = UIColor.systemTeal
+    ///        return UITargetedPreview(view: cell.contentView, parameters: parameters)
+    ///    }
+    /// ```
     func ribbonList(_ ribbonList: RibbonListView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview?
 
     /// Returns a UITargetedPreview that will be used as a preview when dismissing a context menu, overriding the default preview the collection view created
@@ -193,6 +212,26 @@ public protocol RibbonListViewDelegate: AnyObject {
     ///     - ribbonList: The ribbon list containing the item.
     ///     - configuration: The context menu configuration.
     /// - Returns: A view to override the default preview the collection view created
+    ///
+    ///  Example:
+    /// ```swift
+    ///   func ribbonList(_ ribbonList: RibbonListView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+    ///        // Ensure we can get the expected identifier.
+    ///        // Use the identifier to get the UICollectionViewCell that requested context menu presentation
+    ///        guard let configIdentifier = configuration.identifier as? ContextMenuIdentifier else { return nil }
+    ///
+    ///        let indexPath = IndexPath(row: configIdentifier.row, section: configIdentifier.section)
+    ///        // Get the cell for the index of the model.
+    ///        guard let cell = collectionView.cellForItem(at: indexPath) else { return nil }
+    ///
+    ///        let parameters = UIPreviewParameters()
+    ///        let visibleRect = cell.contentView.bounds.insetBy(dx: -10, dy: -10)
+    ///        let visiblePath = UIBezierPath(roundedRect: visibleRect, cornerRadius: 20.0)
+    ///        parameters.visiblePath = visiblePath
+    ///        parameters.backgroundColor = UIColor.systemTeal
+    ///        return UITargetedPreview(view: cell.contentView, parameters: parameters)
+    ///    }
+    /// ```
     func ribbonList(_ ribbonList: RibbonListView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview?
     #endif
 }


### PR DESCRIPTION
removing the proposedIdentifier from the delegate method for the generation of the UIContextMenuConfiguration as it was not needed anymore.
providing a default implementation for the dismissalPreviewForItemAt and highlightPreviewForItemAt delegate methods from the collection view to make sure that it's always visible a preview for the highlighted item also when the context menu is being dismissed.
Providing a way for the RibbonListView class users to implement the default action when the context menu preview view is being tapped