### PR TITLE
Ask to delegate if shouldUpdateFocus before skippingSection

### DIFF
--- a/Sources/RibbonKit/List/RibbonListView.swift
+++ b/Sources/RibbonKit/List/RibbonListView.swift
@@ -535,10 +535,14 @@ extension RibbonListView: UICollectionViewDelegate {
 
     public func collectionView(_ collectionView: UICollectionView, shouldUpdateFocusIn context: UICollectionViewFocusUpdateContext) -> Bool {
         let newContext = RibbonListViewFocusUpdateContext(previouslyFocusedIndexPath: context.previouslyFocusedIndexPath, nextFocusedIndexPath: context.nextFocusedIndexPath)
+        if let shouldUpdateFocus = delegate?.ribbonList(self, shouldUpdateFocusIn: newContext) {
+            return shouldUpdateFocus
+        }
+
         if focusMightSkipSection(context: newContext) {
             return false
         }
-        return delegate?.ribbonList(self, shouldUpdateFocusIn: newContext) ?? true
+        return true
     }
 
     public func indexPathForPreferredFocusedView(in collectionView: UICollectionView) -> IndexPath? {


### PR DESCRIPTION
This MR will enforce to asks the delegate whether we should update focus, and if not, we rely on internal business logic of skipping sections:
```swift
private func focusMightSkipSection(context: RibbonListViewFocusUpdateContext) -> Bool
```