### PR TITLE
Custom Leading Cell in Section

### DIFF
--- a/Sources/RibbonKit/List/RibbonListView.swift
+++ b/Sources/RibbonKit/List/RibbonListView.swift
@@ -102,6 +102,7 @@ open class RibbonListView: UIView {
         collectionView.delegate = self
         collectionView.backgroundColor = .clear
         collectionView.register(RibbonListReusableHostView.self, forSupplementaryViewOfKind: "header")
+        collectionView.register(RibbonListSectionLeadingCell.self)
         addSubview(collectionView)
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -418,6 +419,8 @@ open class RibbonListView: UIView {
     
     private var presentingContextMenuIndexPath: IndexPath?
     private var forcedFocusIndexPath: IndexPath?
+    private var didPerformSectionsWithLeadingComponentInitialScroll = false
+    var sectionsWithLeadingCellComponent = Set<Int>()
 }
 
 extension RibbonListView: RibbonListViewCompositionalLayoutDelegate {
@@ -495,7 +498,11 @@ extension RibbonListView: UICollectionViewDelegate {
     }
     
     public func collectionView(_ collectionView: UICollectionView, canFocusItemAt indexPath: IndexPath) -> Bool {
-        return delegate?.ribbonList(self, canFocusItemAt: indexPath) ?? true
+        delegate?.ribbonList(self, canFocusItemAt: indexPath) ?? true
+    }
+
+    public func viewForLeadingCell(inSection section: Int) -> UIView? {
+        delegate?.ribbonList(self, viewForLeadingCellInSection: section)
     }
 
     private func moveFocusToLastItem(in section: Int) -> Bool {
@@ -555,10 +562,44 @@ extension RibbonListView: UICollectionViewDelegate {
         return delegate?.indexPathForPreferredFocusedView(in: self)
     }
 
+    open override func layoutSubviews() {
+        super.layoutSubviews()
+        guard !didPerformSectionsWithLeadingComponentInitialScroll,
+              !sectionsWithLeadingCellComponent.isEmpty else { return }
+        sectionsWithLeadingCellComponent.forEach {
+            guard let scrollOffset = delegate?.ribbonList(self, defaultScrollOffsetForSectionAt: $0) else { return }
+            scroll(section: $0, horizontallyTo: scrollOffset)
+        }
+        didPerformSectionsWithLeadingComponentInitialScroll = true
+    }
+
+    func scroll(section: Int, horizontallyTo xPosition: CGFloat) {
+        guard let cell = collectionView.cellForItem(at: IndexPath(item: 0, section: section)) else { return }
+        let scroll = cell.superview as! UIScrollView
+        let destinationXPosition = xPosition + abs(scroll.contentInset.left)
+        scroll.setContentOffset(CGPoint(x: destinationXPosition, y: 0), animated: true)
+    }
+
     public func collectionView(_ collectionView: UICollectionView, didUpdateFocusIn context: UICollectionViewFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
         previouslyFocusedIndexPath = context.previouslyFocusedIndexPath
         currentlyFocusedIndexPath = context.nextFocusedIndexPath
         let newContext = RibbonListViewFocusUpdateContext(previouslyFocusedIndexPath: context.previouslyFocusedIndexPath, nextFocusedIndexPath: context.nextFocusedIndexPath)
+        if newContext.nextFocusedIndexPath?.section != newContext.previouslyFocusedIndexPath?.section {
+            if let nextSection = newContext.nextFocusedIndexPath?.section,
+               let cell = collectionView.cellForItem(at: IndexPath(item: 0, section: nextSection)) as? RibbonListSectionLeadingCell {
+                if let scrollOffset = delegate?.ribbonList(self, defaultScrollOffsetForSectionAt: nextSection) {
+                    scroll(section: nextSection, horizontallyTo: scrollOffset)
+                }
+                cell.hideContentView = false
+            }
+            if let previousSection = newContext.previouslyFocusedIndexPath?.section,
+               let cell = collectionView.cellForItem(at: IndexPath(item: 0, section: previousSection)) as? RibbonListSectionLeadingCell {
+                if let scrollOffset = delegate?.ribbonList(self, defaultScrollOffsetForSectionAt: previousSection) {
+                    scroll(section: previousSection, horizontallyTo: scrollOffset)
+                }
+                cell.hideContentView = true
+            }
+        }
         delegate?.ribbonList(self, didUpdateFocusIn: newContext, with: coordinator)
     }
 

--- a/Sources/RibbonKit/List/RibbonListViewDelegate.swift
+++ b/Sources/RibbonKit/List/RibbonListViewDelegate.swift
@@ -162,6 +162,26 @@ public protocol RibbonListViewDelegate: AnyObject {
     /// - Returns: A ribbon configuration to use for the section.
     func ribbonList(_ ribbonList: RibbonListView, configurationForSectionAt section: Int) -> RibbonListSectionConfiguration
 
+    /// Asks the delegate to return the itemIdentifier of the first cell inside the specified section of the ribbon list, to identify.
+    ///
+    /// If you do not implement this method, the ribbon list applies no custom width to the first cell in section.
+    ///
+    /// - Parameters:
+    ///     - ribbonList: An object representing the ribbon list requesting this information.
+    ///     - section: An index number identifying a section of ribbonList.
+    /// - Returns: An hashable value used to identify the first cell in section that should be handled by ribbonList itself as a RibbonListSectionLeadingCell instance.
+    func ribbonList(_ ribbonList: RibbonListView, viewForLeadingCellInSection section: Int) -> UIView?
+
+    /// Asks the delegate to return the itemIdentifier of the first cell inside the specified section of the ribbon list, to identify.
+    ///
+    /// If you do not implement this method, the ribbon list applies no custom width to the first cell in section.
+    ///
+    /// - Parameters:
+    ///     - ribbonList: An object representing the ribbon list requesting this information.
+    ///     - section: An index number identifying a section of ribbonList.
+    /// - Returns: An hashable value used to identify the first cell in section that should be handled by ribbonList itself as a RibbonListSectionLeadingCell instance.
+    func ribbonList(_ ribbonList: RibbonListView, defaultScrollOffsetForSectionAt section: Int) -> CGFloat?
+
     /// Gives the delegate an opportunity to customize the content offset for layout changes and animated updates.
     ///
     /// - Parameters:
@@ -265,6 +285,8 @@ extension RibbonListViewDelegate {
     public func ribbonList(_ ribbonList: RibbonListView, didUpdateFocusIn context: RibbonListViewFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) { }
     public func indexPathForPreferredFocusedView(in ribbonList: RibbonListView) -> IndexPath? { nil }
     public func ribbonList(_ ribbonList: RibbonListView, canFocusItemAt indexPath: IndexPath) -> Bool { true }
+    public func ribbonList(_ ribbonList: RibbonListView, viewForLeadingCellInSection section: Int) -> UIView? { nil }
+    public func ribbonList(_ ribbonList: RibbonListView, defaultScrollOffsetForSectionAt section: Int) -> CGFloat? { nil }
     public func ribbonList(_ ribbonList: RibbonListView, targetContentOffsetForProposedContentOffset proposedContentOffset: CGPoint) -> CGPoint { proposedContentOffset }
 
     public func ribbonListDidEndScrollingAnimation(_ ribbonList: RibbonListView) { }

--- a/Sources/RibbonKit/List/RibbonListViewDiffableDataSource.swift
+++ b/Sources/RibbonKit/List/RibbonListViewDiffableDataSource.swift
@@ -16,9 +16,19 @@ open class RibbonListViewDiffableDataSource<Section: Hashable, Item: Hashable>: 
         self._ribbonList = ribbonList
         super.init()
 
+        let sectionLeadingCellRegistration = UICollectionView.CellRegistration<RibbonListSectionLeadingCell, Item> { _, _, _ in }
+
         dataSource = UICollectionViewDiffableDataSource<Section, Item>(collectionView: _ribbonList.collectionView, cellProvider: {
             [unowned self] collectionView, indexPath, itemIdentifier in
-            cellProvider(_ribbonList, indexPath, itemIdentifier)
+            guard indexPath.item == 0,
+                  let leadingCellView = _ribbonList.viewForLeadingCell(inSection: indexPath.section) else {
+                return cellProvider(_ribbonList, indexPath, itemIdentifier)
+            }
+            let cell = collectionView.dequeueConfiguredReusableCell(using: sectionLeadingCellRegistration, for: indexPath, item: itemIdentifier)
+            cell.setView(leadingCellView)
+            cell.hideContentView = true
+            _ribbonList.sectionsWithLeadingCellComponent.insert(indexPath.section)
+            return cell
         })
 
         dataSource.supplementaryViewProvider = {

--- a/Sources/RibbonKit/List/RibbonListViewDiffableDataSource.swift
+++ b/Sources/RibbonKit/List/RibbonListViewDiffableDataSource.swift
@@ -22,6 +22,9 @@ open class RibbonListViewDiffableDataSource<Section: Hashable, Item: Hashable>: 
             [unowned self] collectionView, indexPath, itemIdentifier in
             guard indexPath.item == 0,
                   let leadingCellView = _ribbonList.viewForLeadingCell(inSection: indexPath.section) else {
+                if _ribbonList.sectionsWithLeadingCellComponent.contains(indexPath.section) {
+                    _ribbonList.sectionsWithLeadingCellComponent.remove(indexPath.section)
+                }
                 return cellProvider(_ribbonList, indexPath, itemIdentifier)
             }
             let cell = collectionView.dequeueConfiguredReusableCell(using: sectionLeadingCellRegistration, for: indexPath, item: itemIdentifier)

--- a/Sources/RibbonKit/Reusable/RibbonListSectionLeadingCell.swift
+++ b/Sources/RibbonKit/Reusable/RibbonListSectionLeadingCell.swift
@@ -1,0 +1,45 @@
+//  Copyright © 2021 Roman Blum. All rights reserved.
+
+import UIKit
+
+class RibbonListSectionLeadingCell: UICollectionViewCell, ReusableView {
+
+    var currentView: UIView?
+
+    var hideContentView: Bool = false {
+        didSet {
+            guard oldValue != hideContentView else { return }
+            UIView.animate(withDuration: 0.3) { [weak self] in
+                guard let self else { return }
+                currentView?.alpha = hideContentView ? 0.0 : 1.0
+            }
+        }
+    }
+
+    override var canBecomeFocused: Bool { false }
+
+    required init?(coder: NSCoder) { nil }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+
+    func setView(_ view: UIView) {
+        defer { currentView = view }
+        currentView?.removeFromSuperview()
+        addSubview(view)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            view.leadingAnchor.constraint(equalTo: leadingAnchor),
+            view.topAnchor.constraint(equalTo: topAnchor),
+            view.trailingAnchor.constraint(equalTo: trailingAnchor),
+            view.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        isUserInteractionEnabled = true
+        currentView?.removeFromSuperview()
+    }
+}


### PR DESCRIPTION
In this pull request it is provided the possibility to RibbonKit users to integrate in specific sections a custom cell (one that is managed Internally by RibbonKit) named `RibbonListSectionLeadingCell`, that will embed a view inside of it. This view is retrieved by RibbonKit via a delegate method that has been added, which is

```
func ribbonList(_ ribbonList: RibbonListView, viewForLeadingCellInSection section: Int) -> UIView?
```

If the value returned from it is non-nil, then a `RibbonListSectionLeadingCell` will be chosen as cell type for the first item in section, and the UIView instance that's returned by this method will be displayed inside the cell.

Since this custom cell is supposed to be an additional component that should appear only when a cell in the section is focused, and it should be only peeked when appearing, a custom scroll behavior has been implemented, for both focus updates and also when the collection view did finish layouting for the first time only (meaning that `layoutSubviews` method in RibbonList has been overridden).
The horizontal scroll offset is determined by the RibbonKit user, that will decide whether there should be any scroll, and if that's the case, the amount of displacement that should occur, by returning a CGFloat value when implementing the other, new delegate method:

```
func ribbonList(_ ribbonList: RibbonListView, defaultScrollOffsetForSectionAt section: Int) -> CGFloat?
```
