### PR TITLE
Fixing Sections Scroll to Default Scroll Position Upon RibbonList's CollectionView First Layout

### DIFF
--- a/Sources/RibbonKit/List/RibbonListViewDiffableDataSource.swift
+++ b/Sources/RibbonKit/List/RibbonListViewDiffableDataSource.swift
@@ -22,7 +22,7 @@ open class RibbonListViewDiffableDataSource<Section: Hashable, Item: Hashable>: 
             [unowned self] collectionView, indexPath, itemIdentifier in
             guard indexPath.item == 0,
                   let leadingCellView = _ribbonList.viewForLeadingCell(inSection: indexPath.section) else {
-                if _ribbonList.sectionsWithLeadingCellComponent.contains(indexPath.section) {
+                if indexPath.item == 0, _ribbonList.sectionsWithLeadingCellComponent.contains(indexPath.section) {
                     _ribbonList.sectionsWithLeadingCellComponent.remove(indexPath.section)
                 }
                 return cellProvider(_ribbonList, indexPath, itemIdentifier)


### PR DESCRIPTION
Fixing the removal of a section from the set of sections with leading cell component, by doing it only in case the cell that is being requested is the first one. This is going to fix the initial scroll of the sections with leading cell component when the collection view is loaded for the first time