### PR TITLE
SectionLeadingCell Disappearing When Dequeueing it

### DIFF
--- a/Sources/RibbonKit/List/RibbonListViewDiffableDataSource.swift
+++ b/Sources/RibbonKit/List/RibbonListViewDiffableDataSource.swift
@@ -87,4 +87,14 @@ open class RibbonListViewDiffableDataSource<Section: Hashable, Item: Hashable>: 
 
     public func sections() -> [Section] { dataSource.snapshot().sectionIdentifiers }
     public func item(for indexPath: IndexPath) -> Item? { dataSource.itemIdentifier(for: indexPath) }
+
+    public func reconfigureItem(_ itemId: Item, animatingDifferences: Bool = true) {
+        reconfigureItems([itemId], animatingDifferences: animatingDifferences)
+    }
+
+    public func reconfigureItems(_ itemIds: [Item], animatingDifferences: Bool = true) {
+        var snapshot = snapshot()
+        snapshot.reconfigureItems(itemIds)
+        apply(snapshot, animatingDifferences: animatingDifferences)
+    }
 }

--- a/Sources/RibbonKit/List/RibbonListViewDiffableDataSource.swift
+++ b/Sources/RibbonKit/List/RibbonListViewDiffableDataSource.swift
@@ -29,7 +29,13 @@ open class RibbonListViewDiffableDataSource<Section: Hashable, Item: Hashable>: 
             }
             let cell = collectionView.dequeueConfiguredReusableCell(using: sectionLeadingCellRegistration, for: indexPath, item: itemIdentifier)
             cell.setView(leadingCellView)
-            cell.hideContentView = true
+            if let focusedCell = _ribbonList.collectionView.visibleCells.first(where: { $0.isFocused }),
+               let focusedIndexPath = _ribbonList.collectionView.indexPath(for: focusedCell) {
+                cell.hideContentView = focusedIndexPath.section != indexPath.section
+            }
+            else {
+                cell.hideContentView = true
+            }
             _ribbonList.sectionsWithLeadingCellComponent.insert(indexPath.section)
             return cell
         })


### PR DESCRIPTION
Fixing disappearing SectonLeadingCell content when scrolling a section that contains one of it, but the focus is still on cells within that same section.

Exposing two new methods from RibbonList's diffable data source to allow items' cells reconfiguration.